### PR TITLE
Fix README clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ A modern, user-friendly Python application for estimating your semester bill at 
 
 1. Clone the repo:
    ```bash
-   git clone https://github.com/Hboahen42/semo_bill.git
-   cd semo_bill
+   git clone https://github.com/Hboahen42/SEMO-Semester-Bill-Estimator.git
+   cd SEMO-Semester-Bill-Estimator
    ```
 
 2. Install the required dependency:


### PR DESCRIPTION
## Summary
- correct the repository URL in the cloning instructions
- update the directory name in the README

## Testing
- `python -m py_compile src/semo_bill.py`

------
https://chatgpt.com/codex/tasks/task_e_68437633eb048325b134a8cf932c60d3